### PR TITLE
Fix an incredibly insecure beginner mistake (piping curl to the shell)

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,8 @@
 
 <p>You can install LuaDist from source using the following one-liner. </p>
 
-<div class="highlight"><pre><span class="nb">echo</span> <span class="s2">"$(curl -fksSL https://tinyurl.com/luadist)"</span> | bash
-</pre></div>
+<div class="highlight"><pre><span class="nv">$ curl -L </span><span class="s2">"https://tinyurl.com/luadist"</span> > <span class="s2">install.sh</span> <span class="nv"># you can review the file</span>
+<span class="nv">$ sh </span><span class="s2">install.sh</span></pre></div>
 
 <p>Windows users can follow our detailed <a href="https://github.com/LuaDist/Repository/wiki/LuaDist%3A-Installation">install instructions</a></p>
 


### PR DESCRIPTION
Don't pipe to your shell: https://www.seancassidy.me/dont-pipe-to-your-shell.html
To further salt the wounds, the command has the following options:
- `-f` - **Fail silently**. Just... why?
- `-k` - Allow connections to SSL sites without certs. What the hell?
- `-S` - Show errors. No idea what this does if combined with `-f`, but I can imagine it's not intended to be there.

This combined with the fact that you use an outside service for shortlinking (tinyurl) is a catastrophe waiting to happen. The PR changes this to separate the commands and adds a comment that you can review the shell script before installing - so that it's no longer a oneliner blackbox for newbies.

A better fix would be to also change tinyurl to a custom short link, preferably something like `luadist.org/get` and include a checksum, but I don't have the time to add that right now.
